### PR TITLE
Add dbcan3 dockerfile

### DIFF
--- a/build_manifest.csv
+++ b/build_manifest.csv
@@ -28,3 +28,4 @@ fastani,1.34
 dbutils,0.1.4
 sratools,3.0.10
 art,2016.06.05
+dbcan3,3.0.6.12

--- a/build_manifest.csv
+++ b/build_manifest.csv
@@ -28,5 +28,5 @@ fastani,1.34
 dbutils,0.1.4
 sratools,3.0.10
 art,2016.06.05
-dbcan3,3.0.6.12
+dbcan3,4.1.4.12
 crispropendb,0.0.1

--- a/dbcan3/Dockerfile
+++ b/dbcan3/Dockerfile
@@ -1,0 +1,33 @@
+FROM continuumio/miniconda3
+
+# set work dir
+WORKDIR /app
+
+# install conda packages
+RUN conda create -y -n run_dbcan python=3.8 dbcan -c conda-forge -c bioconda && conda clean -ya
+
+# add run_dbcan environment to path
+RUN echo "source activate run_dbcan" > ~/.bashrc
+ENV PATH /opt/conda/envs/run_dbcan/bin:$PATH
+
+# download and make the databases
+RUN test -d db || mkdir db
+RUN cd db \
+    && wget http://bcb.unl.edu/dbCAN2/download/Databases/fam-substrate-mapping-08012023.tsv && mv fam-substrate-mapping-08012023.tsv fam-substrate-mapping.tsv \
+    && wget http://bcb.unl.edu/dbCAN2/download/Databases/PUL.faa && makeblastdb -in PUL.faa -dbtype prot \
+    && wget http://bcb.unl.edu/dbCAN2/download/Databases/dbCAN-PUL_12-12-2023.xlsx && mv dbCAN-PUL_12-12-2023.xlsx dbCAN-PUL.xlsx \
+    && wget http://bcb.unl.edu/dbCAN2/download/Databases/dbCAN-PUL.tar.gz && tar xvf dbCAN-PUL.tar.gz && rm dbCAN-PUL.tar.gz \
+    && wget https://bcb.unl.edu/dbCAN2/download/Databases/dbCAN_sub.hmm && hmmpress dbCAN_sub.hmm \
+    && wget https://bcb.unl.edu/dbCAN2/download/Databases/V12/CAZyDB.07262023.fa && mv CAZyDB.07262023.fa CAZyDB.fa  && diamond makedb --in CAZyDB.fa -d CAZy \
+    && wget https://bcb.unl.edu/dbCAN2/download/Databases/V12/dbCAN-HMMdb-V12.txt && mv dbCAN-HMMdb-V12.txt dbCAN.txt && hmmpress dbCAN.txt \
+    && wget https://bcb.unl.edu/dbCAN2/download/Databases/V12/tcdb.fa && diamond makedb --in tcdb.fa -d tcdb \
+    && wget http://bcb.unl.edu/dbCAN2/download/Databases/V12/tf-1.hmm && hmmpress tf-1.hmm \
+    && wget http://bcb.unl.edu/dbCAN2/download/Databases/V12/tf-2.hmm && hmmpress tf-2.hmm \
+    && wget https://bcb.unl.edu/dbCAN2/download/Databases/V12/stp.hmm && hmmpress stp.hmm \
+    && cd ../ && wget http://bcb.unl.edu/dbCAN2/download/Samples/EscheriaColiK12MG1655.fna \
+    && wget http://bcb.unl.edu/dbCAN2/download/Samples/EscheriaColiK12MG1655.faa \
+    && wget http://bcb.unl.edu/dbCAN2/download/Samples/EscheriaColiK12MG1655.gff
+
+ENTRYPOINT ["run_dbcan"]
+
+CMD [ "run_dbcan -h" ]

--- a/dbcan3/Dockerfile
+++ b/dbcan3/Dockerfile
@@ -4,7 +4,7 @@ FROM continuumio/miniconda3
 WORKDIR /app
 
 # install conda packages
-RUN conda create -y -n run_dbcan python=3.8 dbcan -c conda-forge -c bioconda && conda clean -ya
+RUN conda create -y -n run_dbcan python=3.8 dbcan=3.0.6 -c conda-forge -c bioconda && conda clean -ya
 
 # add run_dbcan environment to path
 RUN echo "source activate run_dbcan" > ~/.bashrc

--- a/dbcan3/Dockerfile
+++ b/dbcan3/Dockerfile
@@ -4,7 +4,7 @@ FROM continuumio/miniconda3
 WORKDIR /app
 
 # install conda packages
-RUN conda create -y -n run_dbcan python=3.8 dbcan=3.0.6 -c conda-forge -c bioconda && conda clean -ya
+RUN conda create -y -n run_dbcan python=3.8 dbcan=4.1.4 -c conda-forge -c bioconda && conda clean -ya
 
 # add run_dbcan environment to path
 RUN echo "source activate run_dbcan" > ~/.bashrc

--- a/dbcan3/README.md
+++ b/dbcan3/README.md
@@ -1,0 +1,1 @@
+Just making a note about the versions associated with the Dockerfile.  I will structure it as X.Z  X will refer to the version of dbcan (which itself might have multiple parts ie 3.0.6) and Z the version of the database being used. 


### PR DESCRIPTION
Creating our own dockerfile for dbcan3.  Seems like the official one from `run_dbcan` is being updated but not always being tagged (ie the most recent version is just being tagged "latest").  Thought it would be useful to have our own. This makes use of the latest version of the dbcan database (V12).   I think that I updated the build manifest correctly to make use of the nifty github action to build this! But if not let me know.
